### PR TITLE
Get rid of home button

### DIFF
--- a/lib/header/template.jade
+++ b/lib/header/template.jade
@@ -2,10 +2,8 @@
   a(id='toggleButton', data-toggle="offcanvas", data-target="#sidebar" )
     i.fa.fa-bars
     
-  a.home(href=config.homeLink || '#{config.subPath}/')
-    i.fa.fa-home.header-font-color
   h1#logo
-    a(href=config.organizationUrl)
+    a(href="/")
       - var mobileLogo = !!config.logoMobile
       - var classes = mobileLogo ? 'hidden-xs' : ''
       - if (config.logo)


### PR DESCRIPTION
Petit fix que l'on devait faire depuis un moment. 
J'ai supprimé le bouton home du header et remis un lien vers la racine de l'app sur le logo de l'organisation.
Merci d'accepter la PR, j'ai testé en local ça marche nickel.